### PR TITLE
Decoupling busi nodes and conn/tran nodes.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -62,7 +62,7 @@ object Build extends sbt.Build {
 
 object Dependencies {
   val SPRAY_VERSION = "1.3.0"
-  val AKKA_VERSION = "2.3.0"
+  val AKKA_VERSION = "2.3.1"
 
   val spray_websocket = "com.wandoulabs" % "spray-websocket_2.10" % "0.1"
   val spray_can = "io.spray" % "spray-can" % SPRAY_VERSION

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -44,6 +44,8 @@ spray.socketio {
     actor-selection-resolve-timeout = 10
   }
 
+  seed-nodes = []
+
   # Fully qualified config path which holds the dispatcher configuration
   # to be used for the Namespaces actor.
   namespaces-dispatcher = "akka.actor.default-dispatcher"

--- a/src/main/scala/spray/contrib/socketio/ClusterNamespaceMediator.scala
+++ b/src/main/scala/spray/contrib/socketio/ClusterNamespaceMediator.scala
@@ -1,0 +1,110 @@
+package spray.contrib.socketio
+
+import akka.pattern.ask
+import akka.actor.{ActorLogging, Actor, ActorRef}
+import scala.collection.immutable
+import spray.contrib.socketio
+import akka.contrib.pattern.{ClusterClient, ClusterReceptionistExtension}
+import akka.contrib.pattern.DistributedPubSubMediator.Subscribe
+import akka.contrib.pattern.DistributedPubSubMediator.Publish
+import akka.contrib.pattern.DistributedPubSubMediator.Unsubscribe
+import akka.contrib.pattern.DistributedPubSubMediator.SubscribeAck
+import akka.contrib.pattern.DistributedPubSubMediator.UnsubscribeAck
+import akka.routing.ActorRefRoutee
+import akka.routing.AddRoutee
+import akka.routing.GetRoutees
+import akka.routing.RemoveRoutee
+import akka.routing.RoundRobinGroup
+
+object ClusterNamespaceMediator {
+
+  case class Subscribe(topic: String, group: String, ref: ActorRef)
+
+  case class Unsubscribe(topic: String, group: String, ref: ActorRef)
+
+}
+
+/**
+ * A cluster singleton actor running on ConnectionActive nodes to manage subscriptions
+ *
+ */
+//TODO make this actor persistent
+class ClusterNamespaceMediator extends Actor with ActorLogging {
+
+  var topicToSubscriptions: immutable.Map[String, immutable.Map[String, ActorRef]] = Map.empty
+
+  ClusterReceptionistExtension(context.system).registerService(self)
+
+  def getSubscription(topic: String, group: String): Option[ActorRef] = {
+    if (topicToSubscriptions.contains(topic) && topicToSubscriptions(topic).contains(group)) {
+      Some(topicToSubscriptions(topic)(group))
+    } else {
+      None
+    }
+  }
+
+  def getOrElseInsertSubscription(topic: String, group: String, subscription: ActorRef): ActorRef = {
+    val opt = getSubscription(topic, group)
+    if (opt.isDefined) {
+      opt.get
+    } else {
+      //TODO use ConsistentHashingGroup
+      val router = context.actorOf(RoundRobinGroup(List()).props(), topic + "-" + group)
+      if (topicToSubscriptions.contains(topic)) {
+        topicToSubscriptions += topic -> (topicToSubscriptions(topic) + (group -> router))
+      } else {
+        topicToSubscriptions += topic -> Map(group -> router)
+      }
+      router
+    }
+  }
+
+  override def receive: Receive = {
+    case x @ ClusterNamespaceMediator.Subscribe(topic, group, subscription) =>
+      val subscriber = sender()
+      val router = getOrElseInsertSubscription(topic, group, subscription)
+      import context.dispatcher
+      router ! AddRoutee(ActorRefRoutee(subscription))
+      (router ? GetRoutees)(socketio.actorResolveTimeout) onSuccess {
+        case _ => subscriber ! SubscribeAck(Subscribe(topic, subscription))
+      }
+
+    case x @ ClusterNamespaceMediator.Unsubscribe(topic, group, subscription) =>
+      val subscriber = sender()
+      val ack = UnsubscribeAck(Unsubscribe(topic, subscription))
+      val opt = getSubscription(topic, group)
+      if (opt.isDefined) {
+        val router = opt.get
+        router ! RemoveRoutee(ActorRefRoutee(subscription))
+        import context.dispatcher
+        (router ? GetRoutees)(socketio.actorResolveTimeout) onSuccess {
+          case _ => subscriber ! ack
+        }
+      } else {
+        subscriber ! ack
+      }
+
+    case Publish(topic: String, msg: Any) =>
+      topicToSubscriptions.get(topic) foreach (_.values foreach (_ ! msg))
+
+    case x => log.info("unhandled : " + x)
+  }
+
+  //override def receiveRecover: Receive = ???
+}
+
+/**
+ * ClusterNamespaceMediatorProxy is running on the namespace nodes
+ *
+ * @param path [[ClusterNamespaceMediator]] singleton path
+ * @param client [[ClusterClient]] to access SocketIO Cluster
+ */
+class ClusterNamespaceMediatorProxy(path: String, client: ActorRef) extends Actor with ActorLogging {
+  override def receive: Actor.Receive = {
+    case Subscribe(topic, ref) =>
+      client forward ClusterClient.Send(path, ClusterNamespaceMediator.Subscribe(topic, context.system.name, ref), false)
+    case Unsubscribe(topic, ref) =>
+      client forward ClusterClient.Send(path, ClusterNamespaceMediator.Unsubscribe(topic, context.system.name, ref), false)
+    case x: Publish => client forward ClusterClient.Send(path, x, false)
+  }
+}

--- a/src/main/scala/spray/contrib/socketio/LocalConnectionActive.scala
+++ b/src/main/scala/spray/contrib/socketio/LocalConnectionActive.scala
@@ -8,8 +8,7 @@ import akka.actor.Terminated
 import scala.collection.concurrent
 import akka.contrib.pattern.DistributedPubSubMediator.{ Publish, Unsubscribe, SubscribeAck, Subscribe }
 
-class LocalConnectionActive(val mediator: ActorRef) extends ConnectionActive with Actor with ActorLogging {
-  import ConnectionActive._
+class LocalConnectionActive(val namespaceMediator: ActorRef, val broadcastMediator: ActorRef) extends ConnectionActive with Actor with ActorLogging {
 
   // have to call after log created
   enableCloseTimeout()
@@ -17,16 +16,14 @@ class LocalConnectionActive(val mediator: ActorRef) extends ConnectionActive wit
   def receive = working
 }
 
-
-class LocalConnectionActiveResolver(mediator: ActorRef) extends Actor with ActorLogging {
-  import context.dispatcher
+class LocalConnectionActiveResolver(val namespaceMediator: ActorRef, val broadcastMediator: ActorRef) extends Actor with ActorLogging {
 
   def receive = {
     case ConnectionActive.CreateSession(sessionId: String) =>
       context.child(sessionId) match {
         case Some(_) =>
         case None =>
-          val connectActive = context.actorOf(Props(classOf[LocalConnectionActive], mediator), name = sessionId)
+          val connectActive = context.actorOf(Props(classOf[LocalConnectionActive], namespaceMediator, broadcastMediator), name = sessionId)
           context.watch(connectActive)
       }
 
@@ -42,31 +39,31 @@ class LocalConnectionActiveResolver(mediator: ActorRef) extends Actor with Actor
 
 
 object LocalMediator {
-  private val topicToSubscitptions = concurrent.TrieMap[String, Set[ActorRef]]()
+  private val topicToSubscriptions = concurrent.TrieMap[String, Set[ActorRef]]()
 }
 
 class LocalMediator extends Actor with ActorLogging {
   import LocalMediator._
 
-  def subscitptionsFor(topic: String): Set[ActorRef] = {
-    topicToSubscitptions.getOrElseUpdate(topic, Set[ActorRef]())
+  def subscriptionsFor(topic: String): Set[ActorRef] = {
+    topicToSubscriptions.getOrElseUpdate(topic, Set[ActorRef]())
   }
 
   def receive: Receive = {
-    case x @ Subscribe(topic, subscitption) =>
-      val subs = subscitptionsFor(topic)
-      topicToSubscitptions(topic) = subs + subscitption
-      context.watch(subscitption)
+    case x @ Subscribe(topic, subscriptions) =>
+      val subs = subscriptionsFor(topic)
+      topicToSubscriptions(topic) = subs + subscriptions
+      context.watch(subscriptions)
       sender() ! SubscribeAck(x)
 
-    case Unsubscribe(topic, subscitption) =>
-      topicToSubscitptions.get(topic) match {
+    case Unsubscribe(topic, subscriptions) =>
+      topicToSubscriptions.get(topic) match {
         case Some(xs) =>
-          val subs = xs - subscitption
+          val subs = xs - subscriptions
           if (subs.isEmpty) {
-            topicToSubscitptions -= topic
+            topicToSubscriptions -= topic
           } else {
-            topicToSubscitptions(topic) = subs
+            topicToSubscriptions(topic) = subs
           }
 
         case None =>
@@ -74,18 +71,18 @@ class LocalMediator extends Actor with ActorLogging {
 
     case Terminated(ref) =>
       var topicsToRemove = List[String]()
-      for { (topic, xs) <- topicToSubscitptions } {
+      for { (topic, xs) <- topicToSubscriptions } {
         val subs = xs - ref
         if (subs.isEmpty) {
           topicsToRemove ::= topic
         } else {
-          topicToSubscitptions(topic) = subs
+          topicToSubscriptions(topic) = subs
         }
       }
-      topicToSubscitptions --= topicsToRemove
+      topicToSubscriptions --= topicsToRemove
 
     case Publish(topic: String, msg: Any) =>
-      topicToSubscitptions.get(topic) foreach { subs => subs foreach (_ ! msg) }
+      topicToSubscriptions.get(topic) foreach { subs => subs foreach (_ ! msg) }
   }
 }
 

--- a/src/main/scala/spray/contrib/socketio/SocketIONamespaceExtension.scala
+++ b/src/main/scala/spray/contrib/socketio/SocketIONamespaceExtension.scala
@@ -1,0 +1,77 @@
+package spray.contrib.socketio
+
+import akka.actor._
+import akka.pattern.ask
+import akka.japi.Util.immutableSeq
+import scala.collection.concurrent.TrieMap
+import spray.contrib.socketio.namespace.Namespace
+import scala.concurrent.Await
+import spray.contrib.socketio.SocketIOGuardian.{Start, Started}
+import akka.contrib.pattern.ClusterClient
+import scala.collection.immutable
+import spray.contrib.socketio.SocketIOGuardian.Started
+import spray.contrib.socketio.SocketIOGuardian.Start
+import scala.Some
+
+object SocketIONamespaceExtension extends ExtensionId[SocketIONamespaceExtension] with ExtensionIdProvider {
+  override def get(system: ActorSystem): SocketIONamespaceExtension = super.get(system)
+
+  override def lookup(): ExtensionId[_ <: Extension] = SocketIONamespaceExtension
+
+  override def createExtension(system: ExtendedActorSystem): SocketIONamespaceExtension = new SocketIONamespaceExtension(system)
+}
+
+class SocketIONamespaceExtension(system: ExtendedActorSystem) extends Extension {
+  /**
+   * INTERNAL API
+   */
+  private[socketio] object Settings {
+    val shardingName = system.settings.config.getString("akka.contrib.cluster.sharding.guardian-name")
+    val config = system.settings.config.getConfig("spray.socketio")
+    val isCluster: Boolean = config.getString("mode") == "cluster"
+    println("list:" + config.getList("seed-nodes"))
+    val SeedNodes: Seq[String] = immutableSeq(config.getStringList("seed-nodes"))
+  }
+
+  import Settings._
+
+  private lazy val namespaces = new TrieMap[String, ActorRef]
+
+  private lazy val guardian = system.actorOf(Props[SocketIOGuardian], "socketio-guardian")
+
+  private lazy val client = if (isCluster) {
+    system.actorOf(ClusterClient.props(SeedNodes map (system.actorSelection) toSet), "socketio-cluster-client")
+  } else ActorRef.noSender
+
+  val mediator = if (isCluster) system.actorOf(Props(classOf[ClusterNamespaceMediatorProxy], s"/user/${SocketIOExtension.mediatorName}/${SocketIOExtension.mediatorSingleton}", client)) else SocketIOExtension(system).namespaceMediator
+
+  lazy val resolver = if (isCluster) system.actorOf(Props(classOf[ClusterConnectionActiveResolverProxy], s"/user/${shardingName}/${SocketIOExtension.shardName}", client)) else SocketIOExtension(system).resolver
+
+  def startNamespace(endpoint: String) {
+    implicit val timeout = system.settings.CreationTimeout
+    val name = "socketio-namespace-" + { if (endpoint == "") "global" else endpoint }
+    val startMsg = Start(name, Props(classOf[Namespace], endpoint, mediator))
+    val Started(namespaceRef) = Await.result(guardian ? startMsg, timeout.duration)
+    namespaces(endpoint) = namespaceRef
+  }
+
+  def namespace(endpoint: String): ActorRef = namespaces.get(endpoint) match {
+    case None      => throw new IllegalArgumentException(s"Namespace endpoint [$endpoint] must be started first")
+    case Some(ref) => ref
+  }
+}
+
+private[socketio] object SocketIOGuardian {
+  final case class Start(name: String, entryProps: Props) extends NoSerializationVerificationNeeded
+  final case class Started(ref: ActorRef) extends NoSerializationVerificationNeeded
+}
+
+private[socketio] class SocketIOGuardian extends Actor {
+  override def receive: Actor.Receive = {
+    case Start(name, entryProps) =>
+      val ref: ActorRef = context.child(name).getOrElse {
+        context.actorOf(entryProps, name = name)
+      }
+      sender() ! Started(ref)
+  }
+}

--- a/src/main/scala/spray/contrib/socketio/examples/SimpleServer.scala
+++ b/src/main/scala/spray/contrib/socketio/examples/SimpleServer.scala
@@ -7,8 +7,7 @@ import rx.lang.scala.Observer
 import spray.can.Http
 import spray.can.server.UHttp
 import spray.can.websocket.frame.Frame
-import spray.contrib.socketio.SocketIOExtension
-import spray.contrib.socketio.SocketIOServerConnection
+import spray.contrib.socketio.{SocketIONamespaceExtension, SocketIOExtension, SocketIOServerConnection}
 import spray.contrib.socketio.packet.EventPacket
 import spray.contrib.socketio.namespace.Namespace
 import spray.contrib.socketio.namespace.Namespace.OnData
@@ -76,7 +75,8 @@ object SimpleServer extends App with MySslConfiguration {
 
   implicit val system = ActorSystem()
   val socketioExt = SocketIOExtension(system)
-  implicit val resolver = socketioExt.resolver
+  val namespaceExt = SocketIONamespaceExtension(system)
+  implicit val resolver = namespaceExt.resolver
 
   val observer = new Observer[OnEvent] {
     override def onNext(value: OnEvent) {
@@ -109,8 +109,8 @@ object SimpleServer extends App with MySslConfiguration {
     eventChannel.subscribe(observer)
   }
 
-  socketioExt.startNamespace("testendpoint")
-  socketioExt.namespace("testendpoint") ! Namespace.Subscribe(subscription)
+  namespaceExt.startNamespace("testendpoint")
+  namespaceExt.namespace("testendpoint") ! Namespace.Subscribe(subscription)
 
   val server = system.actorOf(Props(classOf[SocketIOServer], resolver), name = "socketio-server")
 

--- a/src/main/scala/spray/contrib/socketio/examples/benchmark/SocketIOTestServer.scala
+++ b/src/main/scala/spray/contrib/socketio/examples/benchmark/SocketIOTestServer.scala
@@ -8,8 +8,7 @@ import rx.lang.scala.Observer
 import spray.can.Http
 import spray.can.server.UHttp
 import spray.can.websocket.frame.Frame
-import spray.contrib.socketio.SocketIOExtension
-import spray.contrib.socketio.SocketIOServerConnection
+import spray.contrib.socketio.{SocketIONamespaceExtension, SocketIOExtension, SocketIOServerConnection}
 import spray.contrib.socketio.namespace.Namespace
 import spray.contrib.socketio.namespace.Namespace.OnData
 import spray.contrib.socketio.namespace.Namespace.OnEvent
@@ -35,8 +34,8 @@ object SocketIOTestServer extends App {
   }
 
   implicit val system = ActorSystem()
-  val socketioExt = SocketIOExtension(system)
-  implicit val resolver = SocketIOExtension(system).resolver
+  SocketIOExtension(system)
+  implicit val resolver = SocketIONamespaceExtension(system).resolver
 
   val observer = new Observer[OnEvent] with Serializable {
     override def onNext(value: OnEvent) {
@@ -63,8 +62,8 @@ object SocketIOTestServer extends App {
     eventChannel.subscribe(observer)
   }
 
-  socketioExt.startNamespace("")
-  socketioExt.namespace("") ! Namespace.Subscribe(subscription)
+  SocketIONamespaceExtension(system).startNamespace("")
+  SocketIONamespaceExtension(system).namespace("") ! Namespace.Subscribe(subscription)
 
   val server = system.actorOf(Props(classOf[SocketIOServer], resolver), name = "socketio-server")
 

--- a/src/main/scala/spray/contrib/socketio/namespace/Namespace.scala
+++ b/src/main/scala/spray/contrib/socketio/namespace/Namespace.scala
@@ -116,7 +116,7 @@ class Namespace(endpoint: String, mediator: ActorRef) extends Actor with ActorLo
           isMediatorSubscribed = true
           action()
         case Failure(ex) =>
-          log.warning("Failed to subscribe to medietor on topic {}: {}", socketio.topicForNamespace(endpoint), ex.getMessage)
+          log.warning("Failed to subscribe to mediator on topic {}: {}", socketio.topicForNamespace(endpoint), ex.getMessage)
       }
     } else {
       action()


### PR DESCRIPTION
1. move busi nodes out of the socketio cluster
2. busi nodes will register themselves to the cluster, and the cluster use ClusterNamespaceMediator to route (by RoundRobin etc.) OnPacket msg to one of the busi nodes within the same group (same system name).
